### PR TITLE
Directly provides releases as binaries instead of .tar.gz

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,8 @@ builds:
     ldflags:
       - -s -w -X github.com/edgelaboratories/fusion/cmd.version={{.Tag}}
 archives:
-  - replacements:
+  - format: binary
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows


### PR DESCRIPTION
This makes it simpler to include in Docker images as we don't have to
unarchive it and it's a single binary anyway.