### PR TITLE
deps: bump golangci-lint to v1.42

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.37
+          version: v1.42

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,10 @@ linters:
     - forbidigo
     - gochecknoglobals
     - gochecknoinits
+    - golint # deprecated
+    - interfacer # deprecated
+    - maligned # deprecated
+    - scopelint # deprecated
     - wsl
 
 issues:


### PR DESCRIPTION
Bumping golangci-lint to v1.42 and disabling the deprecated linters.