### PR TITLE
feat: bump Go to 1.20 and golangci-lint to 1.51

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.20.x
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42
+          version: v1.51

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,23 @@ linters:
   disable:
     - dupl
     - exhaustivestruct
+    - exhaustruct
     - forbidigo
     - gochecknoglobals
     - gochecknoinits
+    - wsl
+    - deadcode # deprecated
     - golint # deprecated
+    - ifshort # deprecated
     - interfacer # deprecated
     - maligned # deprecated
+    - nosnakecase # deprecated
+    - rowserrcheck # deprecated
     - scopelint # deprecated
-    - wsl
+    - structcheck # deprecated
+    - structcheck # deprecated
+    - varcheck # deprecated
+    - wastedassign # deprecated
 
 issues:
   exclude-rules:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -23,12 +23,12 @@ func merge(cfg *config.Config, outputFilename string, sourceFiles ...string) err
 	return writeToFile(cfg, outputFilename)
 }
 
-func writeToFile(w io.WriterTo, outputFilename string) error {
+func writeToFile(writer io.WriterTo, outputFilename string) error {
 	if verbose {
 		color.Green("creating output file: %s", outputFilename)
 	}
 
-	f, err := os.Create(outputFilename)
+	file, err := os.Create(outputFilename)
 	if err != nil {
 		return fmt.Errorf("failed to create the output file: %w", err)
 	}
@@ -37,7 +37,7 @@ func writeToFile(w io.WriterTo, outputFilename string) error {
 		if verbose {
 			color.Green("closing output file: %s", outputFilename)
 		}
-		if err = f.Close(); err != nil {
+		if err = file.Close(); err != nil {
 			color.Red("failed to close the output file:", err)
 		}
 	}()
@@ -45,7 +45,7 @@ func writeToFile(w io.WriterTo, outputFilename string) error {
 	if verbose {
 		color.Green("writing result to file: %s", outputFilename)
 	}
-	_, err = w.WriteTo(f)
+	_, err = writer.WriteTo(file)
 	if err != nil {
 		return fmt.Errorf("failed to write to the output file: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelaboratories/fusion
 
-go 1.17
+go 1.20
 
 require (
 	github.com/fatih/color v1.14.1
@@ -8,7 +8,6 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -27,4 +26,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Bumping Go to 1.20 in an attempt to help #76. I took this opportunity to bump golangci-lint and fix errors/warnings.