### PR TITLE
fix(ci): goreleaser needs complete checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
 
       - name: Release
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,7 @@ archives:
     name_template: >-
       {{- .ProjectName }}_
       {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Shallow clones mean it cannot produce the changelog